### PR TITLE
specify a specific version to download/build

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Install using sudo dnf install bitwig-studio-4.4.8-1.fc37.x86_64.rpm
 
 If you already have downloaded the .deb package (e.g. for a beta pre-release), supply the path as the first argument:
 ```
-$ ./bitwig.rpm.sh ~/Downloads/bitwig-studio-9.1beta1.deb
+$ ./bitwig-rpm.sh ~/Downloads/bitwig-studio-9.1beta1.deb
 Extracting bitwig-studio-9.1beta1.deb...
 Building RPM...
 [...]

--- a/README.md
+++ b/README.md
@@ -2,15 +2,18 @@
 Downloads the latest Bitwig Studio and creates an RPM for it.
 
 Only depends on rpm-build, not on Debian tools.
+``` shell
+$ sudo dnf install rpm-build
+```
 
 Bitwig depends on the v8 implementation of JPEG, i.e. libjpeg.so.8. The
 implementation shipping with Fedora is v6, so you need to first enable an additional COPR repository by running
-```
+``` shell
 $ sudo dnf copr enable aflyhorse/libjpeg
 ```
 
 To create the RPM package for the latest stable release, run
-```
+``` shell
 $ ./bitwig-rpm.sh
 Determining latest stable version...
 Downloading bitwig-studio-4.4.8.deb...
@@ -19,12 +22,29 @@ RPM created.
 Install using sudo dnf install bitwig-studio-4.4.8-1.fc37.x86_64.rpm
 ```
 
-If you already have downloaded the .deb package (e.g. for a beta pre-release), supply the path as the first argument:
+If you want to download a specific version, supply the version number to download as the first argument:
+``` shell
+$ ./bitwig-rpm.sh 4.4.10
+Finding version 4.4.10...
+Downloading https://downloads.bitwig.com/4.4.10/bitwig-studio-4.4.10.deb
+[...]
+RPM created.
+Install using sudo dnf install bitwig-studio-4.4.10-1.fc42.x86_64.rpm
 ```
+
+If you already have downloaded the .deb package (e.g. for a beta pre-release), supply the path as the first argument:
+``` shell
 $ ./bitwig-rpm.sh ~/Downloads/bitwig-studio-9.1beta1.deb
 Extracting bitwig-studio-9.1beta1.deb...
 Building RPM...
 [...]
 RPM created.
 Install using sudo dnf install bitwig-studio-9.1beta1-1.fc62.x86_64.rpm
+```
+
+Automatically install the created RPM package by using command substitution to execute the script and pass the name of the RPM to a `dnf install` command
+``` shell
+$ sudo dnf install $(./bitwig-rpm.sh) -y
+$ sudo dnf install $(./bitwig-rpm.sh 4.4.10) -y
+$ sudo dnf install $(./bitwig-rpm.sh ~/Downloads/bitwig-studio-9.1beta1.deb) -y
 ```

--- a/bitwig-rpm.sh
+++ b/bitwig-rpm.sh
@@ -62,7 +62,7 @@ function extract_deb()
 {
 	echo Extracting $(basename $1)... 1>&2
 	OUTPUT_DIRECTORY=rpmbuild/SOURCES
-	rm -rf $OUTPUT_DIRECTORY
+	rm -rf $OUTPUT_DIRECTORY/{*.xz,*.zst}
 	mkdir -p $OUTPUT_DIRECTORY
 	ar x --output $OUTPUT_DIRECTORY $1
 }

--- a/bitwig-rpm.sh
+++ b/bitwig-rpm.sh
@@ -3,8 +3,14 @@ SPEC=bitwig-studio.spec
 
 function get_download_url()
 {
-	echo "Determining latest stable version..." 1>&2
-	RELATIVE_URL=$(curl --silent -L bitwig.com | grep -Eo 'dl[^"]*installer_linux')
+	if [ $# -eq 0 ]
+	then
+		echo "Determining latest stable version..." 1>&2
+		RELATIVE_URL=$(curl --silent -L bitwig.com | grep -Eo 'dl[^"]*installer_linux')
+	else
+		echo "Finding version $1" 1>&2
+		RELATIVE_URL=dl/Bitwig%20Studio/$1/installer_linux
+	fi
 	FULL_URL=https://www.bitwig.com/$RELATIVE_URL
 	curl -L --head -w '%{url_effective}' $FULL_URL 2>/dev/null | tail -n1
 }
@@ -12,7 +18,12 @@ function get_download_url()
 # Returns the path to the downloaded archive
 function download_bitwig()
 {
-	DOWNLOAD_URL=$(get_download_url)
+	if [ $# -eq 0 ]
+	then
+		DOWNLOAD_URL=$(get_download_url)
+	else
+		DOWNLOAD_URL=$(get_download_url $1)
+	fi
 	TARGET_PATH=rpmbuild/SOURCES
 	FILENAME=$(basename $(echo $DOWNLOAD_URL | sed 's/?.*//'))
 
@@ -39,8 +50,9 @@ function check_if_already_built()
 	rpm=$(rpm_basename)
 
 	if [ -f $rpm ]; then
-		echo RPM package already built
-		echo Install using sudo dnf install $rpm
+		echo RPM package already built 1>&2
+		echo -n "Install using sudo dnf install " 1>&2
+		echo $rpm
 		exit 0
 	fi
 }
@@ -48,7 +60,7 @@ function check_if_already_built()
 # Arguments: $1: path to debian package
 function extract_deb()
 {
-	echo Extracting $(basename $1)...
+	echo Extracting $(basename $1)... 1>&2
 	OUTPUT_DIRECTORY=rpmbuild/SOURCES
 	mkdir -p $OUTPUT_DIRECTORY
 	ar x --output $OUTPUT_DIRECTORY $1
@@ -56,8 +68,15 @@ function extract_deb()
 
 function create_rpmspec()
 {
+	TARBALL_CONTROL=control.tar.xz
+	TARBALL_DATA=data.tar.xz
+	if [ ! -f $OUTPUT_DIRECTORY/$TARBALL_CONTROL ]; then
+		TARBALL_CONTROL=control.tar.zst
+		TARBALL_DATA=data.tar.zst
+	fi
+
 	CONTROL=$(mktemp)
-	tar axf $OUTPUT_DIRECTORY/control.tar.zst ./control -O > $CONTROL
+	tar axf $OUTPUT_DIRECTORY/$TARBALL_CONTROL ./control -O > $CONTROL
 
 	echo "%global _topdir ./rpmbuild"
 	echo "%global __brp_mangle_shebangs %{nil}"
@@ -74,7 +93,7 @@ function create_rpmspec()
 
 	echo "License: Proprietary"
 	echo "URL:   $(grep Homepage $CONTROL | sed 's/Homepage: //')"
-	echo "SOURCE:  rpmbuild/SOURCES/data.tar.zst"
+	echo "SOURCE:  rpmbuild/SOURCES/$TARBALL_DATA"
 	echo
 
 	echo "%description"
@@ -92,7 +111,7 @@ function create_rpmspec()
 
 	echo "%files"
 	echo /opt/bitwig-studio
-	LIST=$(tar tf rpmbuild/SOURCES/data.tar.zst | grep /usr | sed s/^.//g)
+	LIST=$(tar tf rpmbuild/SOURCES/$TARBALL_DATA | grep /usr | sed s/^.//g)
 	for x in $LIST; do # Filter existing system directories
 		[ ! -d $x ] && echo $x;
 	done
@@ -102,18 +121,22 @@ function create_rpmspec()
 
 function build_rpm()
 {
-	echo "Building RPM..."
+	echo "Building RPM..." 1>&2
 	QA_RPATHS=$(( 0x0001|0x0002 )) rpmbuild --build-in-place -bb $SPEC &&
 	RPM_FILE=rpmbuild/RPMS/x86_64/$(rpm_basename) &&
 	mv $RPM_FILE "$PWD" &&
-	echo &&
-	echo RPM created. &&
-	echo Install using sudo dnf install $(basename $RPM_FILE)
+	echo  1>&2 &&
+	echo RPM created. 1>&2 &&
+	echo -n "Install using sudo dnf install " 1>&2 &&
+	echo $(basename $RPM_FILE)
 }
 
 if [ $# -eq 0 ]
 then
 	DEBIAN_PKG=$(download_bitwig)
+elif [[ $1 =~ [0-9]+\.[0-9]+\.[0-9]+ ]]
+then
+	DEBIAN_PKG=$(download_bitwig $1)
 else
 	DEBIAN_PKG=$1
 fi

--- a/bitwig-rpm.sh
+++ b/bitwig-rpm.sh
@@ -8,7 +8,7 @@ function get_download_url()
 		echo "Determining latest stable version..." 1>&2
 		RELATIVE_URL=$(curl --silent -L bitwig.com | grep -Eo 'dl[^"]*installer_linux')
 	else
-		echo "Finding version $1" 1>&2
+		echo "Finding version $1..." 1>&2
 		RELATIVE_URL=dl/Bitwig%20Studio/$1/installer_linux
 	fi
 	FULL_URL=https://www.bitwig.com/$RELATIVE_URL
@@ -62,6 +62,7 @@ function extract_deb()
 {
 	echo Extracting $(basename $1)... 1>&2
 	OUTPUT_DIRECTORY=rpmbuild/SOURCES
+	rm -rf $OUTPUT_DIRECTORY
 	mkdir -p $OUTPUT_DIRECTORY
 	ar x --output $OUTPUT_DIRECTORY $1
 }


### PR DESCRIPTION
A few different changes here:

1. If the user passes a version string in format `#.#.#` instead of passing the path for a specific local DEB file to use,  the script will attempt to download the DEB for that version.
2. Supports either `*.tar.xz` or `*.tar.zst` in DEB contents, whichever the script actually finds in `rpmbuild/SOURCES`. I see in commit 03476d9cb76451df3fab9f7831e2f3c0572bedc6 that the script had been changed to look for `.zst`, but in the 4.4.10 DEB I downloaded just today, I found that the contents were actually `.xz`. It seems the DEBs for newer versions of Bitwig Studio indeed do use `zst`, but the DEBs for older versions still contain the older `xz` format tarballs.
3. Changed the way `echo` commands worked so that the RPM filename gets output in such a way that allows for automatic unattended installation of the RPM after building. To do so, the user would activate the script like so:  
``` shell
sudo dnf install $(./bitwig-rpm.sh) -y
```
4. Fixed a small typo in README