### PR TITLE
fix: updated download page URL

### DIFF
--- a/bitwig-rpm.sh
+++ b/bitwig-rpm.sh
@@ -5,7 +5,7 @@ function get_download_url()
 {
 	if [ $# -eq 0 ]; then
 		echo "Determining latest stable version..." 1>&2
-		RELATIVE_URL=$(curl --silent -L bitwig.com | grep -Eo 'dl[^"]*installer_linux')
+		RELATIVE_URL=$(curl --silent -L bitwig.com/download/ | grep -Eo 'dl[^"]*installer_linux')
 	else
 		echo "Finding version $1..." 1>&2
 		RELATIVE_URL=dl/Bitwig%20Studio/$1/installer_linux


### PR DESCRIPTION
While the manual download URL from one's account is still the same, the exposed download URLs for .deb packages are now under `bitwig.com/download/...`.

The `get_download_url()` function broke with the release of 6.0, but this fixes it.