### PR TITLE
Added support for `--beta` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,48 +2,59 @@
 Downloads the latest Bitwig Studio and creates an RPM for it.
 
 Only depends on rpm-build, not on Debian tools.
-``` shell
+```sh
 $ sudo dnf install rpm-build
 ```
 
 Bitwig depends on the v8 implementation of JPEG, i.e. libjpeg.so.8. The
 implementation shipping with Fedora is v6, so you need to first enable an additional COPR repository by running
-``` shell
+```sh
 $ sudo dnf copr enable aflyhorse/libjpeg
 ```
 
-To create the RPM package for the latest stable release, run
-``` shell
+To create the RPM package for the latest stable release, run:
+```sh
 $ ./bitwig-rpm.sh
 Determining latest stable version...
-Downloading bitwig-studio-4.4.8.deb...
+Downloading Bitwig Studio 6.0.11...
 [...]
 RPM created.
-Install using sudo dnf install bitwig-studio-4.4.8-1.fc37.x86_64.rpm
+Install using sudo dnf install bitwig-studio-6.0.11.fc44.x86_64.rpm
+```
+
+If you want to download the latest beta release, run:
+```sh
+$ ./bitwig-rpm.sh --beta
+Determining latest beta line...
+Determining latest beta version...
+Downloading Bitwig Studio 6.1-beta-4...
+[...]
+RPM created.
+Install using sudo dnf install bitwig-studio-6.1-beta-4.fc44.x86_64.rpm
 ```
 
 If you want to download a specific version, supply the version number to download as the first argument:
-``` shell
+```sh
 $ ./bitwig-rpm.sh 4.4.10
 Finding version 4.4.10...
 Downloading https://downloads.bitwig.com/4.4.10/bitwig-studio-4.4.10.deb
 [...]
 RPM created.
-Install using sudo dnf install bitwig-studio-4.4.10-1.fc42.x86_64.rpm
+Install using sudo dnf install bitwig-studio-4.4.10-1.fc44.x86_64.rpm
 ```
 
 If you already have downloaded the .deb package (e.g. for a beta pre-release), supply the path as the first argument:
-``` shell
-$ ./bitwig-rpm.sh ~/Downloads/bitwig-studio-9.1beta1.deb
+```sh
+$ ./bitwig-rpm.sh ~/Downloads/bitwig-studio-6.1beta1.deb
 Extracting bitwig-studio-9.1beta1.deb...
 Building RPM...
 [...]
 RPM created.
-Install using sudo dnf install bitwig-studio-9.1beta1-1.fc62.x86_64.rpm
+Install using sudo dnf install bitwig-studio-6.1beta1-1.fc44.x86_64.rpm
 ```
 
 Automatically install the created RPM package by using command substitution to execute the script and pass the name of the RPM to a `dnf install` command
-``` shell
+```sh
 $ sudo dnf install $(./bitwig-rpm.sh) -y
 $ sudo dnf install $(./bitwig-rpm.sh 4.4.10) -y
 $ sudo dnf install $(./bitwig-rpm.sh ~/Downloads/bitwig-studio-9.1beta1.deb) -y

--- a/bitwig-rpm.sh
+++ b/bitwig-rpm.sh
@@ -49,6 +49,15 @@ function download_bitwig()
 	echo $TARGET_PATH/$FILENAME
 }
 
+function rpm_basename()
+{
+	base=$(basename -s .deb $DEBIAN_PKG)
+	fedora_release=$(cut -d ' ' -f 3 /etc/redhat-release)
+	arch=$(uname -m)
+
+	echo $base-1.fc$fedora_release.$arch.rpm
+}
+
 function check_if_already_built()
 {
 	rpm=$(rpm_basename)

--- a/bitwig-rpm.sh
+++ b/bitwig-rpm.sh
@@ -1,11 +1,27 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SPEC=bitwig-studio.spec
 
 function get_download_url()
 {
 	if [ $# -eq 0 ]; then
 		echo "Determining latest stable version..." 1>&2
-		RELATIVE_URL=$(curl --silent -L bitwig.com/download/ | grep -Eo 'dl[^"]*installer_linux')
+		RELATIVE_URL=$(curl --silent -L bitwig.com/download/ | grep -Eo 'dl/Bitwig%20Studio/[0-9]+\.[0-9]+(\.[0-9]+)?/installer_linux' | head -n1)
+	elif [ "$1" == "--beta" ]; then
+		echo "Determining latest beta line..." 1>&2
+		STABLE=$(curl --silent -L bitwig.com/download/ | grep -Eo 'dl/Bitwig%20Studio/[0-9]+\.[0-9]+(\.[0-9]+)?/installer_linux' | head -n1 | grep -Eo '[0-9]+\.[0-9]+')
+		MAJOR=$(echo "$STABLE" | cut -d. -f1)
+		MINOR=$(echo "$STABLE" | cut -d. -f2)
+
+		while curl -s -o /dev/null -L --head -w '%{http_code}' "https://www.bitwig.com/dl/Bitwig%20Studio/${MAJOR}.$((MINOR+1))%20Beta%201/installer_linux" | grep -q 200; do
+			MINOR=$((MINOR+1))
+		done
+
+		echo "Determining latest beta version..." 1>&2
+		N=1
+		while curl -s -o /dev/null -L --head -w '%{http_code}' "https://www.bitwig.com/dl/Bitwig%20Studio/${MAJOR}.${MINOR}%20Beta%20$((POINT+1))/installer_linux" | grep -q 200; do
+			POINT=$((POINT+1))
+		done
+		RELATIVE_URL="dl/Bitwig%20Studio/${MAJOR}.${MINOR}%20Beta%20${POINT}/installer_linux"
 	else
 		echo "Finding version $1..." 1>&2
 		RELATIVE_URL=dl/Bitwig%20Studio/$1/installer_linux
@@ -24,21 +40,13 @@ function download_bitwig()
 
 	TARGET_PATH=rpmbuild/SOURCES
 	FILENAME=$(basename $(echo $DOWNLOAD_URL | sed 's/?.*//'))
-
-	echo "Downloading $(echo $DOWNLOAD_URL | sed 's/?.*//')" 1>&2
+	VERSION=$(echo "$DOWNLOAD_URL" | grep -oP 'bitwig-studio-\K.*(?=\.deb)')
+	
+	echo -e "Downloading \e[1mBitwig Studio $(echo "${VERSION}\e[0m...\n${DOWNLOAD_URL}" | sed 's/?.*//')" 1>&2
 	curl --create-dirs --output-dir $TARGET_PATH \
 		--remote-name -C - $DOWNLOAD_URL
 
 	echo $TARGET_PATH/$FILENAME
-}
-
-function rpm_basename()
-{
-	base=$(basename -s .deb $DEBIAN_PKG)
-	fedora_release=$(cut -d ' ' -f 3 /etc/redhat-release)
-	arch=$(uname -m)
-
-	echo $base-1.fc$fedora_release.$arch.rpm
 }
 
 function check_if_already_built()
@@ -135,8 +143,8 @@ function build_rpm()
 
 if [ $# -eq 0 ]; then
 	DEBIAN_PKG=$(download_bitwig)
-elif [[ $1 =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
-	DEBIAN_PKG=$(download_bitwig $1)
+elif [ "$1" == "--beta" ] || [[ $1 =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+	DEBIAN_PKG=$(download_bitwig "$1")
 else
 	DEBIAN_PKG=$1
 fi


### PR DESCRIPTION
Hello again, I added an additional condition for being able to parse `--beta` flags in order to retrieve the latest beta release.

Unfortunately, since Bitwig doesn't publicly expose beta links, one needs to have the actual link for the existing beta version to parse it through curl. Therefore, the only way I could go about it was with adding point release iterations of a hypothetical future release based on the stable version and the latest version is logically the one before the script returns a "link does not exist" error.

It's a silly method, but I just tried it and it works fine. Any improvements / optimizations are more than welcome, of course.